### PR TITLE
Support CPM

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -6,12 +6,21 @@ target_include_directories(HashLibrary PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-include(FetchContent)
+# FIXME (aw): CPM doesn't play well yet with FetchContent, so we have to
+#             work around
+if(COMMAND CPMAddPackage)
+    CPMAddPackage(
+        NAME libfmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 8.1.1
+    )
+else()
+    include(FetchContent)
+    FetchContent_Declare(
+        libfmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 8.1.1
+    )
 
-FetchContent_Declare(
-    libfmt
-    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 8.1.1
-)
-
-FetchContent_MakeAvailable(libfmt)
+    FetchContent_MakeAvailable(libfmt)
+endif()


### PR DESCRIPTION
- currently, CPM and FetchContent won't play well together if they
  reference the same dependency
- this is a workaround, it uses CPMAddPackage, if the function is
  defined

Signed-off-by: aw <aw@pionix.de>