### PR TITLE
Fix: Setting the correct security bits in generate_nid_from_nmk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(slac VERSION 0.3.0
+project(slac VERSION 0.3.1
         DESCRIPTION "Simple ISO15118-3 SLAC implementation"
 		LANGUAGES CXX C
 )

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -58,8 +58,9 @@ void generate_nid_from_nmk(uint8_t nid[slac::defs::NID_LEN], const uint8_t nmk[s
     // use leftmost 52 bits of the hash output
     // left most bit should be bit 7 of the nid
     memcpy(nid, hash, slac::defs::NID_LEN - 1); // (bits 52 - 5)
-    nid[slac::defs::NID_LEN - 1] = slac::defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT |
-                                   (((uint8_t)hash[6]) >> slac::defs::NID_MOST_SIGNIFANT_BYTE_SHIFT);
+    nid[slac::defs::NID_LEN - 1] =
+        (slac::defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT << slac::defs::NID_SECURITY_LEVEL_OFFSET) |
+        ((static_cast<uint8_t>(hash[6])) >> slac::defs::NID_MOST_SIGNIFANT_BYTE_SHIFT);
 }
 
 } // namespace utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 target_link_libraries(${PROJECT_NAME}_unit_test PRIVATE
         ${GTEST_LIBRARIES}
+        slac::slac
 )
 
 add_test(${PROJECT_NAME}_unit_test ${PROJECT_NAME}_unit_test)

--- a/tests/libslac_unit_test.cpp
+++ b/tests/libslac_unit_test.cpp
@@ -2,6 +2,8 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include <gtest/gtest.h>
+#include <slac/slac.hpp>
+
 namespace libslac {
 class LibSLACUnitTest : public ::testing::Test {
 protected:
@@ -15,4 +17,14 @@ protected:
 TEST_F(LibSLACUnitTest, test_invalid_datetime) {
     ASSERT_TRUE(1 == 1);
 }
+
+TEST_F(LibSLACUnitTest, test_generate_nid_from_nmk_check_security_bits) {
+    uint8_t nid[slac::defs::NID_LEN] = {0};
+    const uint8_t sample_nmk[] = {0x34, 0x52, 0x23, 0x54, 0x45, 0xae, 0xf2, 0xd4,
+                                  0x55, 0xfe, 0xff, 0x31, 0xa3, 0xb3, 0x03, 0xad};
+
+    slac::utils::generate_nid_from_nmk(nid, sample_nmk);
+    ASSERT_TRUE((nid[6] >> 4) == 0x00);
+}
+
 } // namespace libslac


### PR DESCRIPTION
## Describe your changes
Fixing a bug in generate_nid_from_nmk(). Now the correct bits are set.
Adding a simple unit test. 

## Issue ticket number and link
#9 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

